### PR TITLE
chore: fixed crash if you have multiple versions installed

### DIFF
--- a/Tanji.Core.Infrastructure/Configuration/PlatformPaths.cs
+++ b/Tanji.Core.Infrastructure/Configuration/PlatformPaths.cs
@@ -9,4 +9,5 @@ public readonly record struct PlatformPaths
     public readonly string RootPath { get; init; }
     public required string ClientPath { get; init; }
     public required string ExecutablePath { get; init; }
+    public required Int32 Version { get; init; }
 }

--- a/Tanji.Core.Infrastructure/Configuration/PostConfigureTanjiOptions.cs
+++ b/Tanji.Core.Infrastructure/Configuration/PostConfigureTanjiOptions.cs
@@ -30,13 +30,25 @@ internal sealed class PostConfigureTanjiOptions : IPostConfigureOptions<TanjiOpt
 
         foreach (Installation installation in options.Versions.Installations)
         {
+            if (platformPaths.ContainsKey(installation.Platform))
+            {
+                if(platformPaths[installation.Platform].Version < int.Parse(installation.Version))
+                {
+                    platformPaths.Remove(installation.Platform);
+                }
+                else
+                {
+                    continue;
+                }
+            }
+
             platformPaths.Add(installation.Platform, new PlatformPaths
             {
                 Platform = installation.Platform,
-
                 RootPath = installation.Path,
                 ClientPath = Path.Combine(installation.Path, PlatformConverter.ToClientName(installation.Platform)),
-                ExecutablePath = Path.Combine(installation.Path, PlatformConverter.ToExecutableName(installation.Platform))
+                ExecutablePath = Path.Combine(installation.Path, PlatformConverter.ToExecutableName(installation.Platform)),
+                Version = int.Parse(installation.Version)
             });
         }
     }


### PR DESCRIPTION
It crashes because it tries to add an already existing key in dictionary. In my case was "Unity" because I have two different versions installed. Now it choose the newest version.